### PR TITLE
osd::devices allow working on dmcrypt block devices.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.vdi
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,16 @@
 Vagrant::Config.run do |config|
   config.vm.box = "wheezy64"
   config.vm.box_url = "http://os.enocloud.com:8080/v1/AUTH_08972d4e0424497483de1c0a5123ea9b/public/wheezy64.box"
-  
-  config.vm.customize ["modifyvm", :id, "--nictype1", "virtio"]
-  config.vm.customize ["modifyvm", :id, "--macaddress1", "auto"]
+
+  Vagrant.configure("2") do |config|
+  # Place holder for kvm.
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    vb.customize ["modifyvm", :id, "--macaddress1", "auto"]
+
+  end
+end
 
   (0..2).each do |i|
     config.vm.define "mon#{i}" do |mon|

--- a/lib/facter/ceph_osd_bootstrap_key.rb
+++ b/lib/facter/ceph_osd_bootstrap_key.rb
@@ -35,8 +35,10 @@ end
 blkid = Facter::Util::Resolution.exec("blkid")
   blkid and blkid.each_line do |line|
   if line =~ /^\/dev\/(.+):.*UUID="([a-fA-F0-9\-]+)"/
-    device = $1
+    device_orig = $1
     uuid = $2
+    device = device_orig.sub(/.*\//, "")
+
 
     Facter.add("blkid_uuid_#{device}") do
       setcode do

--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -60,7 +60,6 @@ size=1024m -n size=64k ${name}",
 
   $blkid_uuid_fact = "blkid_uuid_${devname}"
   notify {"$blkid_uuid_fact":}
-  notify {"$blkid_uuid_fact":}
   notify { "BLKID FACT ${devname}: ${blkid_uuid_fact}": }
   $blkid = inline_template('<%= scope.lookupvar(blkid_uuid_fact) or "undefined" %>')
   notify { "BLKID ${devname}: ${blkid}": }

--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -60,7 +60,7 @@ define ceph::osd::device (
     }
   }
   else {
-    $dev_partition = $full_dev_path}
+    $dev_partition = $full_dev_path
     exec { "mkfs_${devname}":
       command => "mkfs.xfs -f -d agcount=${::processorcount} -l size=1024m -n size=64k ${dev_partition}",
       unless  => "xfs_admin -l ${name}",

--- a/templates/ceph.conf-osd.erb
+++ b/templates/ceph.conf-osd.erb
@@ -1,6 +1,6 @@
 [osd.<%= @name %>]
    host = <%= @hostname %>
-   devs = <%= @device %>1
+   devs = <%= @device %>
    cluster addr = <%= @cluster_addr %>
    public addr = <%= @public_addr %>
 


### PR DESCRIPTION
Allowing to create a partition on top of a `dmcrypt` block devices. As well you can enable `gpt` or not.

  ceph::osd::device { "/dev/mapper/osd-${id}":
    partition_table      => false,
    partition_table_type => none,
  }

This will apply a `osd` to the `dmcrypt` devices without a `gpt` layout. When you want to use
a `gpt` table on the `dmcrypt` set this:

  ceph::osd::device { "/dev/mapper/osd-${id}":
    partition_table      => true,
    partition_table_type => gpt,
    dmcrypt_device
  }

This will create a `gpt` on the `dmcrypt` block devices. By default a `gpt` partition table will create.

  define ceph::osd::device (
    $partition_table = true,
    $partition_table_type = gpt,
    $dmcrypt_device = false,
  )

This is my solution for [Unable to create filesystem on dmcrypt devices - puppet ceph issue #13](https://github.com/enovance/puppet-ceph/issues/13). By default nothing changes for the call of the `osd::device`. 

Only when required when having a `dmcrypt` device. More things will come later.

Note: How the `dmcrypt` will be unblock isn't take care of. 


so far
4k3nd0