### PR TITLE
Fixes fsck issue

### DIFF
--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -17,6 +17,7 @@
 #
 
 define ceph::osd::device (
+  $mount_at_boot = true
 ) {
 
   include ceph::osd
@@ -78,7 +79,7 @@ size=1024m -n size=64k ${name}1",
       mount { $osd_data:
         ensure  => mounted,
         device  => "${name}1",
-        atboot  => true,
+        atboot  => $mount_at_boot,
         fstype  => 'xfs',
         options => 'rw,noatime,inode64',
         pass    => 2,

--- a/spec/defines/ceph_osd_device_spec.rb
+++ b/spec/defines/ceph_osd_device_spec.rb
@@ -94,15 +94,39 @@ ceph::key { 'admin':
         'ensure' => 'directory'
       ) }
 
-      it { should contain_mount('/var/lib/ceph/osd/osd.56').with(
-        'ensure'  => 'mounted',
-        'device'  => '/dev/device1',
-        'atboot'  => true,
-        'fstype'  => 'xfs',
-        'options' => 'rw,noatime,inode64',
-        'pass'    => 2,
-        'require' => ['Exec[mkfs_device]', 'File[/var/lib/ceph/osd/osd.56]']
-      ) }
+      context 'with mount_at_boot => true' do
+        let :params do
+          {
+            :mount_at_boot => true
+          }
+        end
+        it { should contain_mount('/var/lib/ceph/osd/osd.56').with(
+          'ensure'  => 'mounted',
+          'device'  => '/dev/device1',
+          'atboot'  => true,
+          'fstype'  => 'xfs',
+          'options' => 'rw,noatime,inode64',
+          'pass'    => 2,
+          'require' => ['Exec[mkfs_device]', 'File[/var/lib/ceph/osd/osd.56]']
+        ) }
+      end
+
+      context 'with mount_at_boot => false' do
+        let :params do
+          {
+            :mount_at_boot => false
+          }
+        end
+        it { should contain_mount('/var/lib/ceph/osd/osd.56').with(
+          'ensure'  => 'mounted',
+          'device'  => '/dev/device1',
+          'atboot'  => false,
+          'fstype'  => 'xfs',
+          'options' => 'rw,noatime,inode64',
+          'pass'    => 2,
+          'require' => ['Exec[mkfs_device]', 'File[/var/lib/ceph/osd/osd.56]']
+        ) }
+      end
 
       it { should contain_exec('ceph-osd-mkfs-56').with(
         'command' => 'ceph-osd -c /etc/ceph/ceph.conf -i 56 --mkfs --mkkey --osd-uuid dummy-uuid-1234


### PR DESCRIPTION
If we set atboot to true, it will write auto mount info to /etc/fstab.
When server restart, fsck.xfs will be called, it will check and repair
XFS filesystem in /etc/fstab. This will be inconsistent in /etc/fstab when we
removing an OSD. In this case, fsck.xfs will hang in server startup.

I remove atboot parameter, when server startup, puppet agent will mount
correct OSDs.