### PR TITLE
role: add classes to configure Ceph clusters through simple ENCs

### DIFF
--- a/examples/site-roles.pp
+++ b/examples/site-roles.pp
@@ -1,0 +1,28 @@
+$ceph_release           = 'dumpling'
+$ceph_fsid              = '07d28faa-48ae-4356-a8e3-19d5b81e159e'
+$ceph_mon_secret        = 'AQD7kyJQQGoOBhAAqrPAqSopSwPrrfMMomzVdw=='
+$ceph_public_interface  = 'eth0'
+$ceph_cluster_interface = 'eth1'
+$ceph_osd_devices       = '/dev/sdb'
+
+Exec {
+  path => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+}
+
+node 'ceph-mon0.test' {
+  $ceph_export_admin_key = 'true'
+  include ceph::role::mon
+}
+
+node 'ceph-mon1.test' {
+  include ceph::role::mon
+}
+
+node 'ceph-mon2.test' {
+  include ceph::role::mon
+}
+
+node /ceph-osd.?\.test/ {
+  include ceph::role::osd
+}
+

--- a/manifests/role/base.pp
+++ b/manifests/role/base.pp
@@ -1,0 +1,105 @@
+# ceph::role::base
+#
+# Base class for role-based configuration of Ceph nodes
+#
+# This class installs Ceph packages, and configures Ceph,
+# according to global variables set either in a site manifest
+# or in an External Node Classifier (ENC).
+#
+# It has no class parameters in order to be extensible via
+# "inherits".
+#
+# This class understands the following global variables:
+#
+# ceph_release           - the Ceph release codename, like "dumpling"
+#                          or "firefly" (no default)
+# ceph_fsid              - the filesystem ID (no default)
+# ceph_auth_type         - the authentication type (default 'cephx')
+# ceph_cluster_interface - the interface to use for internal
+#                          cluster communications. This class
+#                          gleans the corresponding network
+#                          addresses and netmasks from facts
+#                          available through facter
+#                          (default 'eth0')
+# ceph_public_interface  - the interface to use for communications
+#                          with Ceph clients (default 'eth1')
+# ceph_package_ensure    - whether to just make sure the ceph
+#                          package is installed ('present', default),
+#                          or is the latest version available ('latest').
+class ceph::role::base {
+
+  # Style note: it looks like poor form that these variables
+  # do not use the explicit top scope ("$::ceph_release" etc.),
+  # but this is deliberate. While global variables and variables
+  # set by an ENC are in the top scope, node variables
+  # (set per node in site.pp) are not. They are in node scope
+  # instead. The node scope, however, is anonymous, so it does
+  # not set any explicit prefix. So to allow variables to be set
+  # both globally and at the node level, use the unqualified
+  # references.
+  # See additional information in:
+  # http://docs.puppetlabs.com/puppet/3/reference/lang_scope.html#node-scope
+  $release           = $ceph_release
+  $fsid              = $ceph_fsid
+  $auth_type         = pick($ceph_auth_type, 'cephx')
+  $public_interface  = pick($ceph_public_interface, 'eth0')
+  $cluster_interface = pick($ceph_cluster_interface, 'eth1')
+  $package_ensure    = pick($ceph_package_ensure, 'present')
+
+  # This is completely silly. ceph.conf doesn't support
+  # dotted-quad addresses in cluster_network and public_network,
+  # and facter doesn't provide network addresses in CIDR
+  # suffix format.
+  # The right thing to do would be to either teach the ceph.conf
+  # parser about dotted quad notation, or teach facter to expose
+  # something like netmask_cidr, but until that happens, use
+  # this stupid hash to look things up.
+  $cidr_hash = {
+    '255.0.0.0' => 8,
+    '255.128.0.0' => 9,
+    '255.192.0.0' => 10,
+    '255.224.0.0' => 11,
+    '255.240.0.0' => 12,
+    '255.248.0.0' => 13,
+    '255.252.0.0' => 14,
+    '255.254.0.0' => 15,
+    '255.255.0.0' => 16,
+    '255.255.128.0' => 17,
+    '255.255.192.0' => 18,
+    '255.255.224.0' => 19,
+    '255.255.240.0' => 20,
+    '255.255.248.0' => 21,
+    '255.255.252.0' => 22,
+    '255.255.254.0' => 23,
+    '255.255.255.0' => 24,
+    '255.255.255.128' => 25,
+    '255.255.255.192' => 26,
+    '255.255.255.224' => 27,
+    '255.255.255.240' => 28,
+    '255.255.255.248' => 29,
+    '255.255.255.252' => 30,
+    '255.255.255.254' => 31,
+    '255.255.255.255' => 32,
+  }
+
+  class { 'ceph::apt::ceph':
+    release => $release,
+  }
+
+  class { 'ceph::package':
+    package_ensure => $package_ensure,
+  }
+
+  class { 'ceph::conf':
+    fsid            => $fsid,
+    auth_type       => $auth_type,
+    cluster_network => join([getvar("network_${cluster_interface}"),
+                             $cidr_hash[getvar("netmask_${cluster_interface}")]],
+                             "/"),
+    public_network  => join([getvar("network_${public_interface}"),
+                            $cidr_hash[getvar("netmask_${public_interface}")]],
+                             "/"),
+    require         => Class['ceph::apt::ceph']
+  }
+
+}

--- a/manifests/role/mon.pp
+++ b/manifests/role/mon.pp
@@ -1,0 +1,75 @@
+# ceph::role::mon
+#
+# Class for role-based configuration of Ceph monitor nodes
+#
+# This class configures a Ceph monitor (MON) node
+# according to global variables set either in a site manifest
+# or in an External Node Classifier (ENC).
+#
+# It inherits from ceph::role::base, so a node with the
+# ceph::role::mon class does not necessarily also need to be
+# configured with ceph::role::base.
+
+# This class understands the global variables defined for
+# ceph::role::base, plus the following:
+#
+# ceph_mon_secret        - the MON secret. Must be a base64 encoded
+#                          secret (no default)
+# ceph_mon_id            - the MON ID
+#                          (default is to use the node's hostname)
+#                          or "firefly" (no default)
+# ceph_mon_port          - the port number to listen on
+#                          (default 6789)
+# ceph_mon_address       - the address to listen on
+#                          (if undefined, the default is to
+#                          listen on the IP address associated
+#                          with ceph_public_interface, then
+#                          the host's default IP address)
+# ceph_cluster_interface - the interface to use for internal
+#                          cluster communications. This class
+#                          gleans the corresponding network
+#                          addresses and netmasks from facts
+#                          available through facter
+#                          (default 'eth0')
+# ceph_export_admin_key  - whether to export the initial client.admin key
+#                          from this node (true) or not (false, default).
+#                          Set this to true on only one of your MONs.
+class ceph::role::mon inherits ceph::role::base {
+
+  # Style note: it looks like poor form that these variables
+  # do not use the explicit top scope ("$::ceph_release" etc.),
+  # but this is deliberate. While global variables and variables
+  # set by an ENC are in the top scope, node variables
+  # (set per node in site.pp) are not. They are in node scope
+  # instead. The node scope, however, is anonymous, so it does
+  # not set any explicit prefix. So to allow variables to be set
+  # both globally and at the node level, use the unqualified
+  # references.
+  # See additional information in:
+  # http://docs.puppetlabs.com/puppet/3/reference/lang_scope.html#node-scope
+  $secret       = $ceph_mon_secret
+  $id           = pick($ceph_mon_id, $::hostname)
+  $port         = pick($ceph_mon_port, 6789)
+  $address      = pick($ceph_mon_address,
+                       getvar("ipaddress_${public_interface}"),
+                       $::ipaddress)
+  $export_key   = str2bool(pick($ceph_export_admin_key, 'false'))
+
+  ceph::mon { $id:
+    monitor_secret => $secret,
+    mon_port       => $port,
+    mon_addr       => $address,
+  }
+
+  # ceph_admin_key is not a global variable, it is a facter fact
+  # created by ceph_osd_bootstrap_key.rb. So, this is definitely
+  # in the top scope, and the name should remain fully qualified.
+  if ($export_key) {
+    if !empty($::ceph_admin_key) {
+      @@ceph::key { 'admin':
+        secret       => $::ceph_admin_key,
+        keyring_path => '/etc/ceph/keyring',
+      }
+    }
+  }
+}

--- a/manifests/role/osd.pp
+++ b/manifests/role/osd.pp
@@ -1,0 +1,40 @@
+# ceph::role::osd
+#
+# Class for role-based configuration of Ceph object storage nodes
+#
+# This class configures a Ceph object storage (OSD) node
+# according to global variables set either in a site manifest
+# or in an External Node Classifier (ENC).
+#
+# It inherits from ceph::role::base, so a node with the
+# ceph::role::mon class does not necessarily also need to be
+# configured with ceph::role::base.
+#
+# This class understands the global variables defined for
+# ceph::role::base, plus the following:
+#
+# ceph_osd_devices       - comma-separated list of devices to configure
+#                          as OSDs (no default)
+class ceph::role::osd inherits ceph::role::base {
+
+  # Style note: it looks like poor form that these variables
+  # do not use the explicit top scope ("$::ceph_release" etc.),
+  # but this is deliberate. While global variables and variables
+  # set by an ENC are in the top scope, node variables
+  # (set per node in site.pp) are not. They are in node scope
+  # instead. The node scope, however, is anonymous, so it does
+  # not set any explicit prefix. So to allow variables to be set
+  # both globally and at the node level, use the unqualified
+  # references.
+  # See additional information in:
+  # http://docs.puppetlabs.com/puppet/3/reference/lang_scope.html#node-scope
+  $devices = split($ceph_osd_devices, ',')
+
+  class { 'ceph::osd':
+    public_address  => getvar("::ipaddress_${public_interface}"),
+    cluster_address => getvar("::ipaddress_${cluster_interface}"),
+  }
+
+  ceph::osd::device { $devices: }
+}
+


### PR DESCRIPTION
These classes add the ability to configure MONs and OSDs through the exclusive use of un-parameterized classes, global and node variables. This allows users to configure a Ceph cluster with even a simple ENC such as Puppet Dashboard (or a home-rolled ENC), or by greatly simplified site manifests that are essentially a few variable definitions plus some includes.

An example site manifest, providing identical functionality to the one defined in the currently shipped example site.pp, is also included.

MDS and radosgw configuration still require some extra work in the low-level classes.