### PR TITLE
osd: fix blkid and osd_id detection with strict_variables

### DIFF
--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -48,7 +48,7 @@ size=1024m -n size=64k ${name}1",
 
   $blkid_uuid_fact = "blkid_uuid_${devname}1"
   notify { "BLKID FACT ${devname}: ${blkid_uuid_fact}": }
-  $blkid = inline_template('<%= scope.lookupvar(blkid_uuid_fact) or "undefined" %>')
+  $blkid = inline_template('<%= scope.function_defined(["$"+blkid_uuid_fact]) and scope.lookupvar(blkid_uuid_fact) or "undefined" %>')
   notify { "BLKID ${devname}: ${blkid}": }
 
   if $blkid != 'undefined'  and defined( Ceph::Key['admin'] ){
@@ -60,7 +60,7 @@ size=1024m -n size=64k ${name}1",
 
     $osd_id_fact = "ceph_osd_id_${devname}1"
     notify { "OSD ID FACT ${devname}: ${osd_id_fact}": }
-    $osd_id = inline_template('<%= scope.lookupvar(osd_id_fact) or "undefined" %>')
+    $osd_id = inline_template('<%= scope.function_defined(["$"+osd_id_fact]) and scope.lookupvar(osd_id_fact) or "undefined" %>')
     notify { "OSD ID ${devname}: ${osd_id}":}
 
     if $osd_id != 'undefined' {


### PR DESCRIPTION
When strict_variables is enabled on the puppetmaster, scope.lookupvar()
fails hard when the variable doesn't exist. So we need to explicitely
check wether it exists or not.