### PR TITLE
duplicate ceph::conf definition

### DIFF
--- a/manifests/mds.pp
+++ b/manifests/mds.pp
@@ -34,9 +34,11 @@ define ceph::mds (
   include 'ceph::package'
   include 'ceph::params'
 
-  class { 'ceph::conf':
-    fsid      => $fsid,
-    auth_type => $auth_type,
+  if !defined(Class['ceph::conf']) {
+    class { 'ceph::conf':
+      fsid      => $fsid,
+      auth_type => $auth_type,
+    }
   }
 
   $mds_data_expanded = "${mds_data}/mds.${name}"


### PR DESCRIPTION
If there is a MDS and a MON on the same machine, mds.pp and mon.pp both define ceph::conf.